### PR TITLE
Improve Yahoo trending scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # codex
-Testing Codex in my GitHub Repository
+
+Utility script to scrape trending articles from Yahoo's homepage.
+
+## Setup
+
+Install dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script directly to print the top trending articles:
+
+```bash
+python scrape_trending.py
+```
+
+You can also import `get_trending_articles` in your own scripts.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+requests

--- a/scrape_trending.py
+++ b/scrape_trending.py
@@ -1,42 +1,60 @@
 import requests
 from bs4 import BeautifulSoup
+from typing import List, Tuple
 
-def get_trending_articles():
-    url = 'https://www.yahoo.com/'
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
-    }
+DEFAULT_URL = "https://www.yahoo.com/"
+DEFAULT_ARTICLE_COUNT = 10
+HEADERS = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
 
-    response = requests.get(url, headers=headers)
-    if response.status_code != 200:
-        print(f"Failed to fetch Yahoo homepage: {response.status_code}")
-        return []
 
-    soup = BeautifulSoup(response.content, 'html.parser')
+def fetch_html(url: str) -> str:
+    """Fetch HTML content from a URL.
 
-    trending_articles = []
-    # Yahoo trending stories are often under <a> tags within headlines or promoted lists
-    for link in soup.find_all('a', href=True):
-        text = link.get_text(strip=True)
-        href = link['href']
+    Returns an empty string if the request fails.
+    """
+    try:
+        response = requests.get(url, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        return response.text
+    except requests.RequestException as err:
+        print(f"Failed to fetch {url}: {err}")
+        return ""
 
-        if text and 'https://' in href and len(text.split()) > 3:
-            trending_articles.append((text, href))
 
-    # De-duplicate and return top 10
+def parse_trending_articles(html: str, max_articles: int = DEFAULT_ARTICLE_COUNT) -> List[Tuple[str, str]]:
+    """Parse trending article titles and links from HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    articles: List[Tuple[str, str]] = []
     seen = set()
-    unique_articles = []
-    for title, link in trending_articles:
-        if title not in seen:
-            seen.add(title)
-            unique_articles.append((title, link))
-        if len(unique_articles) >= 10:
-            break
 
-    return unique_articles
+    for link in soup.find_all("a", href=True):
+        title = link.get_text(strip=True)
+        href = link["href"]
 
-if __name__ == "__main__":
+        if title and "https://" in href and len(title.split()) > 3:
+            if title not in seen:
+                seen.add(title)
+                articles.append((title, href))
+                if len(articles) >= max_articles:
+                    break
+
+    return articles
+
+
+def get_trending_articles(url: str = DEFAULT_URL, max_articles: int = DEFAULT_ARTICLE_COUNT) -> List[Tuple[str, str]]:
+    """Return trending article titles and links from Yahoo."""
+    html = fetch_html(url)
+    if not html:
+        return []
+    return parse_trending_articles(html, max_articles)
+
+
+def main() -> None:
     articles = get_trending_articles()
     print("Top Yahoo Trending Articles:\n")
     for i, (title, link) in enumerate(articles, 1):
         print(f"{i}. {title}\n   {link}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor `scrape_trending.py` with type hints and parameterized helpers
- handle request failures gracefully
- document running the scraper
- add `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `python scrape_trending.py` *(fails: Tunnel connection failed)*
- `python -m py_compile scrape_trending.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6906c8a08327ae91229e4d40becb