### PR TITLE
Add basic CMDB web app

### DIFF
--- a/CMDB/README.md
+++ b/CMDB/README.md
@@ -1,0 +1,19 @@
+# CMDB
+
+A lightweight configuration management database (CMDB) for storing database
+instances and their associated accounts.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python CMDB/app.py
+   ```
+3. Open `http://127.0.0.1:5000` in a browser to access the UI.
+
+The application uses SQLite for storage and creates a local `cmdb.db` file in
+the repository.

--- a/CMDB/app.py
+++ b/CMDB/app.py
@@ -1,0 +1,66 @@
+from flask import Flask, render_template, request, redirect, url_for
+from models import db, Database, Account
+
+
+def create_app():
+    """Application factory for the CMDB UI."""
+    app = Flask(__name__)
+
+    # Configure the SQLite database.  In a real deployment this could be
+    # pointed at another RDBMS.
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///cmdb.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    # Initialise the database with this app context.
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+
+    @app.route("/")
+    def index():
+        """List all databases."""
+        databases = Database.query.all()
+        return render_template("index.html", databases=databases)
+
+    @app.route("/database/new", methods=["GET", "POST"])
+    def new_database():
+        """Create a new database entry."""
+        if request.method == "POST":
+            data = Database(
+                name=request.form["name"],
+                environment=request.form.get("environment"),
+                db_type=request.form.get("db_type"),
+                version=request.form.get("version"),
+                dblink_name=request.form.get("dblink_name"),
+                description=request.form.get("description"),
+            )
+            db.session.add(data)
+            db.session.commit()
+            return redirect(url_for("index"))
+        return render_template("new_database.html")
+
+    @app.route("/database/<string:name>", methods=["GET", "POST"])
+    def database_detail(name):
+        """View details for a database and manage its accounts."""
+        database = Database.query.get_or_404(name)
+        if request.method == "POST":
+            account = Account(
+                username=request.form["username"],
+                password=request.form["password"],
+                account_type=request.form.get("account_type"),
+                description=request.form.get("description"),
+                database=database,
+            )
+            db.session.add(account)
+            db.session.commit()
+            return redirect(url_for("database_detail", name=name))
+        return render_template("database_detail.html", database=database)
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    # Running with debug=True for development convenience.  Remove or set
+    # to False in production.
+    app.run(debug=True)

--- a/CMDB/models.py
+++ b/CMDB/models.py
@@ -1,0 +1,43 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Global SQLAlchemy instance for use across the application
+# It will be initialised with the Flask app in app.py
+
+db = SQLAlchemy()
+
+
+class Database(db.Model):
+    """Stores information about a database instance."""
+
+    __tablename__ = "databases"
+
+    # The database name acts as the primary key so that other tables
+    # can reference it directly.
+    name = db.Column(db.String(128), primary_key=True)
+    environment = db.Column(db.String(64))
+    db_type = db.Column(db.String(64))
+    version = db.Column(db.String(64))
+    dblink_name = db.Column(db.String(128))
+    description = db.Column(db.Text)
+
+
+class Account(db.Model):
+    """Represents an account within a database."""
+
+    __tablename__ = "accounts"
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(128), nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+    account_type = db.Column(db.String(64))
+    description = db.Column(db.Text)
+
+    # Foreign key constraint referencing Database.name
+    database_name = db.Column(
+        db.String(128), db.ForeignKey("databases.name"), nullable=False
+    )
+
+    # Establish relationship back to the Database model
+    database = db.relationship(
+        "Database", backref=db.backref("accounts", cascade="all, delete-orphan", lazy=True)
+    )

--- a/CMDB/templates/database_detail.html
+++ b/CMDB/templates/database_detail.html
@@ -1,0 +1,31 @@
+{% extends "layout.html" %}
+
+{% block content %}
+  <h2>{{ database.name }}</h2>
+  <p><strong>Environment:</strong> {{ database.environment }}</p>
+  <p><strong>Type:</strong> {{ database.db_type }}</p>
+  <p><strong>Version:</strong> {{ database.version }}</p>
+  <p><strong>DB Link:</strong> {{ database.dblink_name }}</p>
+  <p><strong>Description:</strong> {{ database.description }}</p>
+
+  <h3>Accounts</h3>
+  {% if database.accounts %}
+    <ul>
+    {% for acct in database.accounts %}
+      <li>{{ acct.username }} ({{ acct.account_type }})</li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p>No accounts for this database.</p>
+  {% endif %}
+
+  <h3>Add Account</h3>
+  <form method="post">
+    <label>Username: <input type="text" name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <label>Account Type: <input type="text" name="account_type"></label><br>
+    <label>Description:<br><textarea name="description"></textarea></label><br>
+    <button type="submit">Add Account</button>
+  </form>
+  <p><a href="{{ url_for('index') }}">Back</a></p>
+{% endblock %}

--- a/CMDB/templates/index.html
+++ b/CMDB/templates/index.html
@@ -1,0 +1,14 @@
+{% extends "layout.html" %}
+
+{% block content %}
+  <p><a href="{{ url_for('new_database') }}">Add Database</a></p>
+  {% if databases %}
+    <ul>
+    {% for db in databases %}
+      <li><a href="{{ url_for('database_detail', name=db.name) }}">{{ db.name }}</a> ({{ db.environment }})</li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p>No databases have been added yet.</p>
+  {% endif %}
+{% endblock %}

--- a/CMDB/templates/layout.html
+++ b/CMDB/templates/layout.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>CMDB</title>
+  </head>
+  <body>
+    <h1>Configuration Management Database</h1>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/CMDB/templates/new_database.html
+++ b/CMDB/templates/new_database.html
@@ -1,0 +1,15 @@
+{% extends "layout.html" %}
+
+{% block content %}
+  <h2>Add Database</h2>
+  <form method="post">
+    <label>Name: <input type="text" name="name" required></label><br>
+    <label>Environment: <input type="text" name="environment"></label><br>
+    <label>Type: <input type="text" name="db_type"></label><br>
+    <label>Version: <input type="text" name="version"></label><br>
+    <label>DB Link: <input type="text" name="dblink_name"></label><br>
+    <label>Description:<br><textarea name="description"></textarea></label><br>
+    <button type="submit">Create</button>
+  </form>
+  <p><a href="{{ url_for('index') }}">Back</a></p>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 beautifulsoup4
 requests
+flask
+flask_sqlalchemy


### PR DESCRIPTION
## Summary
- add Flask-based CMDB subproject for tracking databases and accounts
- implement database and account models with SQLite storage
- provide simple HTML UI for managing databases and credentials

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile CMDB/app.py CMDB/models.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1d893caa48327b80ff8698d3c7ac7